### PR TITLE
Fixes #2 - Add sorting with cool emojis ✊

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prop-types": "15.6.0",
     "react": "16.2.0",
     "react-dom": "16.2.0",
+    "react-motion": "0.5.2",
     "react-sortable-hoc": "0.6.8",
     "react-toastify": "3.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "description": "V2 of https://github.com/kentcdodds/repeat-todo",
   "version": "0.0.66",
   "dependencies": {
-    "react-dom": "16.2.0",
-    "react-beautiful-dnd": "3.0.0",
-    "react": "16.2.0",
-    "prop-types": "15.6.0",
-    "milligram": "1.3.0",
     "firebase": "4.8.1",
-    "glamorous": "4.11.0",
     "glamor": "2.20.40",
+    "glamorous": "4.11.0",
+    "milligram": "1.3.0",
+    "prop-types": "15.6.0",
+    "react": "16.2.0",
+    "react-dom": "16.2.0",
+    "react-sortable-hoc": "0.6.8",
     "react-toastify": "3.2.1"
   },
   "devDependencies": {

--- a/src/handle.css
+++ b/src/handle.css
@@ -1,0 +1,6 @@
+body > .draggable-item-row .draggable-item::after {
+  content: '✊';
+}
+.draggable-item-row .draggable-item::after {
+  content: '✋';
+}

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,15 @@ const SortableItem = SortableElement(
     return (
       <Motion key={id} style={{top: spring(sortIndex * 45)}}>
         {val => (
-          <div className="draggable-item-row">
+          <div
+            className="draggable-item-row"
+            style={{
+              ...val,
+              position: 'absolute',
+              left: 0,
+              right: 0,
+            }}
+          >
             <hr style={{margin: 8}} />
             <Row
               gap={30}


### PR DESCRIPTION
This was a fun one to work on! I got the sorting to work and finally figured out a solution to the ✊ vs ✋ issue but it required adding a separate css file. I was hoping to update the content with props but the element actually gets cloned and appended to the body when you sort so the only thing I could think of was having a custom css selector which has an `::after` that provided the content.

I'm definitely open to thoughts and feedback on the implementation. Here are a couple of my thoughts.

I didn't quite get the `reorderItems` function and the structure of the items. I built my own reorder handler [here](https://github.com/kentcdodds/repeat-todo-v2/compare/master...danseethaler:reorder-issue-2?expand=1#diff-1fdf421c05c1140f6d71444ea2b27638R334). Maybe they could be merged and the data structure could be simplified but I didn't want to mix that with this PR.

The `Motion` doesn't seem to be working when you add or delete an item so I'll have to look at that when I have some more time as well.

Fun project Kent!